### PR TITLE
Improve navigation and clarify content.

### DIFF
--- a/clients.html
+++ b/clients.html
@@ -18,7 +18,7 @@
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-      ga('create', 'UA-35952681-2', 'auto');
+      ga('create', 'UA-79921909-1', 'auto');
       ga('send', 'pageview');
 
     </script>

--- a/contribute.html
+++ b/contribute.html
@@ -80,44 +80,10 @@
 	</section>
         <section>
           <h3>Get started</h3>
-	  <p>Learn how
-	  to <a href="https://github.com/zulip/zulip/blob/master/README.dev.md">set
-	  up a Zulip server development environment</a>!</p>
-
-	  <p>We've written developer documentation, available
-	  on <a href="https://zulip.readthedocs.io">Read The Docs</a>,
-	  that covers
-	  <a href="https://zulip.readthedocs.io/en/latest/new-feature-tutorial.html">how
-	  to write a new feature</a>,
-	  <a href="https://zulip.readthedocs.io/en/latest/translating.html">how
-	  to translate
-	  Zulip</a>, <a href="https://zulip.readthedocs.io/en/latest/markdown.html">our
-	  "Bugdown" flavor of Markdown</a>, and more.</p>
-
-	  <p>Zulip also has
-	  a <a href="https://groups.google.com/forum/#!forum/zulip-devel"
-	  target="_blank">development discussion mailing list</a>
-	  (plus lists
-	  for <a href="https://groups.google.com/forum/#!forum/zulip-ios">iOS
-	  dev</a>
-	  and <a href="https://groups.google.com/forum/#!forum/zulip-android">Android
-	  dev</a>). Please reach out to us if you have any
-	  questions!</p>
+	  <p>Check out <a href="http://zulip.readthedocs.io/en/latest/readme-symlink.html#ways-to-contribute">our
+	  contribution guide</a>, with installation instructions, tutorials, and more!</p>
+	  <p>All our code is <a href="https://github.com/zulip/">on GitHub</a>.</p>
 	</section>
-        <section>
-          <h3>Contribute on GitHub</h3>
-          <p>Clone one of the following repos and submit a pull request!</p>
-          <ul>
-            <li><a href="https://github.com/zulip/zulip">Server and web app</a></li>
-            <li><a href="https://github.com/zulip/zulip-desktop">Desktop</a></li>
-            <li><a href="https://github.com/zulip/zulip-ios">iOS</a></li>
-            <li><a href="https://github.com/zulip/zulip-android">Android</a></li>
-          </ul>
-	  <p>We maintain several more repositories for integrations
-	  and glue
-	  code; <a href="https://github.com/zulip/zulip/blob/master/README.md">see
-	  our README</a>.</p>
-        </section>
 	<section>
 	  <h3>Security</h3>
 	  <p>Please report any potential security issues you discover to

--- a/contribute.html
+++ b/contribute.html
@@ -18,7 +18,7 @@
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-      ga('create', 'UA-35952681-2', 'auto');
+      ga('create', 'UA-79921909-1', 'auto');
       ga('send', 'pageview');
 
     </script>

--- a/contribute.html
+++ b/contribute.html
@@ -56,13 +56,27 @@
       <article>
         <section>
           <h3>We'd love your help</h3>
-          <p>Zulip welcomes all forms of contributions! There's a ton of stuff to do. Here's just a small sampling of ways you can get started:</p>
+          <p>Zulip is licensed under the Apache license and is a
+          friendly open source community that welcomes all forms of
+          contributions! There's a ton of stuff to do -- in
+          development, testing, translation, documentation, and
+          more. Here's just a small sampling of ways you can get
+          started:</p>
           <ul>
-            <li>Write an integration for your favorite service</li>
-            <li>Write a docker file to make Zulip available to dockerized servers</li>
-            <li>Add a service monitoring dashboard</li>
-            <li>Add your favorite emoji</li>
+            <li><a href="https://zulip.readthedocs.io/en/latest/integration-guide.html">Write
+            an integration for your favorite service</a></li>
+            <li>Improve
+            our <a href="https://github.com/zulip/zulip/blob/master/Dockerfile">Dockerfile</a>
+            to make Zulip available to dockerized servers</li>
+            <li><a href="https://zulip.readthedocs.io/en/latest/translating.html">Translate</a>
+            user-visible words into another language</li>
+            <li>Build an efficient process for testing and releasing new versions of the desktop
+            apps</li>
+            <li><a href="https://github.com/zulip/zulip/issues/599">Update our screenshots to
+            show the current Zulip UI</li>
           </ul>
+          <p>And <a href="http://zulip.readthedocs.io/en/latest/roadmap.html">here's our roadmap</a>,
+          so you can see where we're headed in 2016.</p>
 	</section>
         <section>
           <h3>Get started</h3>
@@ -70,9 +84,25 @@
 	  to <a href="https://github.com/zulip/zulip/blob/master/README.dev.md">set
 	  up a Zulip server development environment</a>!</p>
 
-	  <p>Zulip has a growing collection of developer documentation available on <a href="https://zulip.readthedocs.org/">Read The Docs</a>.</p> <!--link!-->
+	  <p>We've written developer documentation, available
+	  on <a href="https://zulip.readthedocs.io">Read The Docs</a>,
+	  that covers
+	  <a href="https://zulip.readthedocs.io/en/latest/new-feature-tutorial.html">how
+	  to write a new feature</a>,
+	  <a href="https://zulip.readthedocs.io/en/latest/translating.html">how
+	  to translate
+	  Zulip</a>, <a href="https://zulip.readthedocs.io/en/latest/markdown.html">our
+	  "Bugdown" flavor of Markdown</a>, and more.</p>
 
-	  <p>Zulip also has a <a href="https://groups.google.com/forum/#!forum/zulip-devel" target="_blank">development discussion mailing list</a>. Please reach out to us if you have any questions!</p>
+	  <p>Zulip also has
+	  a <a href="https://groups.google.com/forum/#!forum/zulip-devel"
+	  target="_blank">development discussion mailing list</a>
+	  (plus lists
+	  for <a href="https://groups.google.com/forum/#!forum/zulip-ios">iOS
+	  dev</a>
+	  and <a href="https://groups.google.com/forum/#!forum/zulip-android">Android
+	  dev</a>). Please reach out to us if you have any
+	  questions!</p>
 	</section>
         <section>
           <h3>Contribute on GitHub</h3>
@@ -83,7 +113,16 @@
             <li><a href="https://github.com/zulip/zulip-ios">iOS</a></li>
             <li><a href="https://github.com/zulip/zulip-android">Android</a></li>
           </ul>
+	  <p>We maintain several more repositories for integrations
+	  and glue
+	  code; <a href="https://github.com/zulip/zulip/blob/master/README.md">see
+	  our README</a>.</p>
         </section>
+	<section>
+	  <h3>Security</h3>
+	  <p>Please report any potential security issues you discover to
+	  zulip-security@googlegroups.com.</p>
+	</section>
       </article>
     </div>
   </body>

--- a/features.html
+++ b/features.html
@@ -19,7 +19,7 @@
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-      ga('create', 'UA-35952681-2', 'auto');
+      ga('create', 'UA-79921909-1', 'auto');
       ga('send', 'pageview');
 
     </script>

--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-      ga('create', 'UA-35952681-2', 'auto');
+      ga('create', 'UA-79921909-1', 'auto');
       ga('send', 'pageview');
 
     </script>

--- a/server.html
+++ b/server.html
@@ -75,7 +75,9 @@
           these sorts of things as they become available, sign up for
           the <a href="https://groups.google.com/forum/#!forum/zulip-announce">Zulip
           announcement list</a>.  Finally, note that
-          the <a href="https://github.com/zulip/zulip/blob/master/README.dev.md">Zulip
+          the <a href="http://zulip.tabbott.net/">developers' chatroom
+          (a running Zulip instance)</a> or the
+          <a href="https://github.com/zulip/zulip/blob/master/README.dev.md">Zulip
           development environment</a> may be a better choice if you
           just want to play around with Zulip and aren't ready to
           commit to setting up a production server with SSL

--- a/server.html
+++ b/server.html
@@ -18,7 +18,7 @@
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-      ga('create', 'UA-35952681-2', 'auto');
+      ga('create', 'UA-79921909-1', 'auto');
       ga('send', 'pageview');
 
     </script>

--- a/server.html
+++ b/server.html
@@ -67,12 +67,13 @@
 	  target="_blank">Zulip development discussion mailing
 	  list</a> for help.</p>
           <p>
-          <p><b>WARNING</b>: This automated installation process expects to
-          be the only thing running on a server (it uses Puppet,
-          etc.).  It's likely additional installation options will be
-          implemented by the community over the coming weeks (both in
-          terms of distros and methods).  If you'd like to hear about
-          these sorts of things as they become available, sign up for
+          <p><b>WARNING</b>: This automated installation process
+          expects to be the only thing running on a server (it uses
+          Puppet, etc.).  It's likely additional installation options
+          will be implemented by the community over the coming weeks
+          (both in terms of distros and methods).  If you'd like to
+          hear about these sorts of things as they become available,
+          sign up for
           the <a href="https://groups.google.com/forum/#!forum/zulip-announce">Zulip
           announcement list</a>.  Finally, note that
           the <a href="http://zulip.tabbott.net/">developers' chatroom
@@ -128,7 +129,7 @@
             <a href="mailto:zulip-help@googlegroups.com">zulip-help@googlegroups.com</a> for troubleshooting help.</p>
 	  </section>
           <section>
-            <a name="integrations"><h4>Integrations</h4></a>
+            <a name="integrations"><h3>Integrations</h3></a>
             <p>Once you have the Zulip server running, you can
 	      reconfigure various options, auth methods, and built-in integrations in
 	      /etc/zulip/settings.py.  In order for these changes to take effect, you will need to restart the server using:

--- a/server.html
+++ b/server.html
@@ -94,29 +94,14 @@
           and email credentials needed to send outgoing email.</p>
         </section>
         <section>
-          <a name="troubleshooting"><h3>Troubleshooting instructions</h3></a>
-          <p>The instructions here are an abbreviated version of the
-          instructions in
-          the <a href="https://github.com/zulip/zulip/blob/master/README.prod.md">Zulip
-          in production README</a>; you will want to consult those
-          instructions once you finish the steps here or if you run
-          into any trouble.
-          <p>
-        </section>
-        <section>
           <a name="install"><h3>Installation</h3></a>
 	  <section>
-	    <p>The installation process should be executed as the root user. Run:
-<div class="terminal">
-  sudo -i
-            </div> 
-	  </section>
-          <section>
             <a name="download"><h4>Download the tarball</h4></a>
-            <p>Download
+            <p>Instructions for downloading
             the <a href="https://www.zulip.com/dist/releases/zulip-server-1.3.13.tar.gz">binary
-            tarball</a>, Verify its sha1sum matches, extract it, and
-            move the resulting directory to /root/zulip:</p>
+            tarball</a>, verifying its sha1sum matches, extracting it, and
+            moving the resulting directory to <code>/root/zulip</code> (where it's expected
+	    to live):</p>
             <div class="terminal">
               cd /root<br />
               wget https://www.zulip.com/dist/releases/zulip-server-1.3.13.tar.gz<br />
@@ -124,65 +109,12 @@
               tar -xf zulip-server-1.3.13.tar.gz<br />
               mv zulip-server-1.3.13 zulip<br />
             </div>
+	  <p>Consult the <a href="https://github.com/zulip/zulip/blob/master/README.prod.md">Zulip
+	    in production README</a> for installation instructions and tips to
+	    troubleshoot common issues.</p>
           </section>
           <section>
-            <a name="ssl"><h4>Install SSL certs</h4></a>
-            <p>Zulip requires HTTPS, so you need to install an SSL certificate here:<br/>
-            /etc/ssl/private/zulip.key<br/>
-            /etc/ssl/certs/zulip.combined-chain.crt<br/>
-            </p>
-            <p>If you don't know how to generate an SSL certificate,
-            you, you can do the following to generate a self-signed certificate:</p>
-              <div class="terminal">
-                apt-get install openssl<br />
-                openssl genrsa -des3 -passout pass:x -out server.pass.key 4096<br />
-                openssl rsa -passin pass:x -in server.pass.key -out zulip.key<br />
-                rm server.pass.key<br />
-                openssl req -new -key zulip.key -out server.csr<br />
-                openssl x509 -req -days 365 -in server.csr -signkey zulip.key -out zulip.combined-chain.crt<br />
-                rm server.csr<br />
-                cp zulip.key /etc/ssl/private/zulip.key<br />
-                cp zulip.combined-chain.crt /etc/ssl/certs/zulip.combined-chain.crt<br />
-              </div>
-            <p>You will eventually want to get a properly signed
-            certificate (and note that at present the Zulip desktop app doesn't
-            support self-signed certificates), but this will let you
-            finish the installation process.</p>
-          </section>
-          <section>
-            <a name="setup"><h4>Run the setup script</h4></a>
-            <div class="terminal">
-              cd /root/zulip<br/>
-              ./scripts/setup/install
-            </div>
-            <p>This may take a while to run, since it will install all the dependencies via apt.</p> 
-          </section>
-          <section>
-            <a name="configure"><h4>Configure Zulip</h4></a>
-            <p>Configure the Zulip server instance by opening
-            /etc/zulip/settings.py with your favorite editor and
-            filling in the settings; you'll want to configure all the
-            "Mandatory settings" plus at least one authentication method.</p>
-          </section>
-          <section>
-            <a name="initdb"><h4>Initialize the database</h4></a>
-            <p>Run the following command:</p>
-            <div class="terminal">
-            su zulip -c /home/zulip/deployments/current/scripts/setup/initialize-database
-            </div>
-  This will create the realm you defined in /etc/zulip/settings.py and the various Zulip notification bots. 
-  It will report an error if you did not fill in all the mandatory
-  settings from /etc/zulip/settings.py. Once this finishes
-  successfully, the main installation process will be complete.</p>
-<p>
-<p>You will then want to consult
-the <a href="https://github.com/zulip/zulip/blob/master/README.prod.md">Zulip
-in production README</a> for how to create your initial administrator
-    account and login, setup integrations, etc., as well as
-  troubleshoot common issues. </a></p>
-          </section>
-          <section>
-            <a name="integrations"><h4>Announcement mailing list</h4></a>
+            <a name="integrations"><h3>Announcement mailing list</h3></a>
 	    <p>We highly recommend signing up for
 	    the <a href="https://groups.google.com/forum/#!forum/zulip-announce">Zulip
 	    announcement mailing list</a> so you will hear about new


### PR DESCRIPTION
- De-duplicate content that lives elsewhere and point to the current canonical source. (We're updating README.prod.md much more often than server.html.)
- Add link to zulip.com/api in top navbar.
- Add more guidance for new contributors.
- Fix several obsolete or unclear links.
- Fix formatting, whitespace, punctuation, and style.

Fixes: zulip/zulip#668.
