### PR TITLE
Add guidance on availability, communicating and applying.

### DIFF
--- a/outreachy-round-13.md
+++ b/outreachy-round-13.md
@@ -1,12 +1,18 @@
 Zulip is a proud participant in [Outreachy](http://outreachy.org/) and
-is currently recruiting Outreachy interns for the upcoming Round
-13. We'll teach you and pay you to improve Zulip, full-time, between
-December 6, 2016 and March 6, 2017.
+is currently helping new open source contributors apply to be
+Outreachy interns for the upcoming Round 13. We'll teach you and pay
+you to improve Zulip, full-time, between December 6, 2016 and March 6,
+2017.
 
 If you're [in a group underrepresented in open source
 communities](https://wiki.gnome.org/Outreachy#Eligibility) and you're
 interested in contributing to Zulip during a paid apprenticeship,
 please apply by October 17th!
+
+(We already have heard from many people interested in applying; if
+you're just hearing about Outreachy now, do also consider [one of the
+other mentoring
+organizations](https://wiki.gnome.org/Outreachy/2016/DecemberMarch#Participating_Organizations).)
 
 # About us
 
@@ -50,7 +56,7 @@ talk with us about [our
 roadmap](https://zulip.readthedocs.io/en/latest/roadmap.html) or your
 questions, and consider applying for an Outreachy internship with us!
 
-# Application tips
+# Application tips, and how to be a strong candidate
 
 Our Outreachy application process opens September 12 and closes
 October 17. [You'll follow the instructions
@@ -69,7 +75,7 @@ Your application should include the following:
 * Some notes on what you are hoping to get out of your twelve-week project.
 * A description of the project you'd like to do, and why you're excited about it.
 * Some notes on why you're excited about working on Zulip.
-* A link to the small initial contribution you did.
+* A link to the small initial contribution(s) you did.
 
 If you're applying for a coding internship: We expect applicants to
 either have experience with the technologies relevant to their project
@@ -83,15 +89,66 @@ be skilled in writing in English for a non-academic audience, and to
 be interested in getting feedback that will help them write accurately
 and accessibly about technology.
 
-We'll be asking for you to publicly post a few sections of your
-proposal -- the project summary, list of deliverables, and timeline --
-someplace public on the Web, such as on your blog, or in a public
-document on a platform like
-[EtherPad](https://public.etherpad-mozilla.org/) or
-[Hackpad](https://hackpad.com) or [Dropbox
-Paper](https://www.dropbox.com)). That way, the whole developer
-community -- not just the mentors and administrators -- have a chance
-to give you feedback and help you improve your proposal.
+We would like you to publicly post a few sections of your proposal --
+the project summary, list of deliverables, and timeline -- someplace
+public on the Web, such as on your blog, sometime before October
+17th. That way, the whole developer community -- not just the mentors
+and administrators -- have a chance to give you feedback and help you
+improve your proposal. See ["let's get started publishing drafts of
+proposals" on our mailing
+list](https://groups.google.com/forum/#!topic/zulip-outreachy-round-13/dhs2wX6RaSo)
+for more details.
+
+As the [application process
+guide](https://wiki.gnome.org/Outreachy#Application_Process) says:
+
+"While only one contribution is required to be considered for the
+program, we find that the strongest applicants make multiple
+contributions throughout the application process, including after the
+application deadline."
+
+We are more interested in candidates if we see them submitting good
+contributions to Zulip projects, helping other applicants on GitHub
+and on our mailing lists and on
+[zulip.tabbott.net](https://zulip.tabbott.net/#narrow/stream/Outreachy.202016-2017/subject/Welcome),
+learning from our suggestions, (trying to solve their own obstacles
+and then asking well-formed
+questions)[https://blogs.akamai.com/2013/10/you-must-try-and-then-you-must-ask.html],
+and developing and sharing project ideas and project proposals that
+are plausible and useful.
+
+Also, you're going to find that people give you links to pages that
+answer your questions. Here's how that often works:
+
+1) you [try to solve your problem until you get stuck, including
+looking through our code and our documentation, then start formulating
+your request for
+help](https://blogs.akamai.com/2013/10/you-must-try-and-then-you-must-ask.html)
+2) you ask your question
+3) someone directs you to a document
+4) you go read that document, and try to use it to answer your question
+5) you find you are confused about a new thing
+6) you ask another question
+7) now that you have demonstrated that you have the ability to read,
+think, and learn new things, someone has a longer talk with you to
+answer your new specific question
+8) you and the other person collaborate to improve the document that you
+read in step 3 :-)
+
+This helps us make a balance between person-to-person discussion and
+documentation that everyone can read, so we save time answering common
+questions but also get everyone the personal help they need. This will
+help you understand the rhythm of help we provide in the developers'
+Zulip livechat -- including why we prefer to give you help in public
+mailing lists and Zulip streams, instead of in one-on-one private
+messages or email. We prefer to hear from you and respond to you in
+public places so more people have a chance to answer the question, and
+to see and benefit from the answer. If that makes you say "aha", also
+see [these tips for new open source
+contributors](https://zulip.tabbott.net/#narrow/stream/Outreachy.202016-2017/topic/Tips.20for.20new.20open.20source.20contributors),
+on how to learn faster and communicate respectfully in open source
+communities.
+
 
 # Project ideas
 
@@ -158,7 +215,7 @@ apps, or other code that integrates with Zulip.
   go for an approach that involves auto-generated documentation
   (etc.).
 
-* Implementing analytics so we can see how people use zulip, see which
+* Implementing analytics so we can see how people use Zulip, see which
   features are valuable, systematically debug performance problems, etc.
 
  - Frontend analytics visualizations: we store a lot of interesting
@@ -185,11 +242,6 @@ and compose a new stream message to the 'Outreachy 2016-2017' stream
 with your name as the topic, and talk with us about what your skills
 are -- we'll find something for you.
 
-As you work towards an initial contribution, it might help you to
-check out [these tips for new open source
-contributors](https://zulip.tabbott.net/#narrow/stream/Outreachy.202016-2017/topic/Tips.20for.20new.20open.20source.20contributors),
-on how to learn faster and communicate respectfully in open source
-communities.
 
 # Mentors
 


### PR DESCRIPTION
Add a heads-up that we won't have enough slots to take all interested Outreachy applicants, and add tips on publishing and strengthening internship applications (including by being a good citizen in shared communication spaces).
