### PR TITLE
Change "server install" links to point to readthedocs.

### DIFF
--- a/clients.html
+++ b/clients.html
@@ -32,7 +32,7 @@
         </div>
         <nav>
           <ul class="downloads">
-            <li><a href="server.html">Server</a></li>
+            <li><a href="https://zulip.readthedocs.io/en/latest/prod.html">Server</a></li>
             <li><a href="clients.html">Clients</a></li>
           </ul>
           <ul>

--- a/contribute.html
+++ b/contribute.html
@@ -32,7 +32,7 @@
         </div>
         <nav>
           <ul class="downloads">
-            <li><a href="server.html">Server</a></li>
+            <li><a href="https://zulip.readthedocs.io/en/latest/prod.html">Server</a></li>
             <li><a href="clients.html">Clients</a></li>
           </ul>
           <ul>

--- a/features.html
+++ b/features.html
@@ -33,7 +33,7 @@
         </div>
         <nav>
           <ul class="downloads">
-            <li><a href="server.html">Server</a></li>
+            <li><a href="https://zulip.readthedocs.io/en/latest/prod.html">Server</a></li>
             <li><a href="clients.html">Clients</a></li>
           </ul>
           <ul>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
         </div>
         <nav>
           <ul class="downloads">
-            <li><a href="server.html">Server</a></li>
+            <li><a href="https://zulip.readthedocs.io/en/latest/prod.html">Server</a></li>
             <li><a href="clients.html">Clients</a></li>
           </ul>
           <ul>
@@ -54,7 +54,7 @@
       <div class="half box">
         <h2>Run your own server</h2>
         <div class="call-to-action">
-          <a class="button" href="server.html">Get started</a> or <a class="button-link" href="features.html">check out the features</a>
+          <a class="button" href="https://zulip.readthedocs.io/en/latest/prod.html">Get started</a> or <a class="button-link" href="features.html">check out the features</a>
         </div>
       </div>
       <div class="half box download-options">

--- a/server.html
+++ b/server.html
@@ -32,7 +32,7 @@
         </div>
         <nav>
           <ul class="downloads">
-            <li><a href="server.html">Server</a></li>
+            <li><a href="https://zulip.readthedocs.io/en/latest/prod.html">Server</a></li>
             <li><a href="clients.html">Clients</a></li>
           </ul>
           <ul>


### PR DESCRIPTION
(Right now this is a 404! PR pending to add the doc this would point to.)

Also it'd be cool to make `https://zulip.org/server.html` actually give an HTTP redirect to the new page, for the benefit of anyone following links there from outside. Not sure how best/easiest to do that.
